### PR TITLE
Fix compilation of the codesign program

### DIFF
--- a/codesign/Program.cs
+++ b/codesign/Program.cs
@@ -1,14 +1,8 @@
-﻿using Azure.Core;
-using Azure.Identity;
+﻿using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using Claunia.PropertyList;
 using System.CommandLine;
-using System.CommandLine.Binding;
-using System.CommandLine.Invocation;
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
 using System.Security.Cryptography.X509Certificates;
-using Melanzana.CodeSign;
 using RSAKeyVaultProvider;
 
 namespace Melanzana.CodeSign
@@ -17,15 +11,20 @@ namespace Melanzana.CodeSign
     {
         public static int Main(string[] args)
         {
+            var identity = new Argument<string>("identity", "Name of signing identity or \"-\" for ad-hoc signing");
+            var path = new Argument<string>("path", "Path to bundle or executable on disk");
+            var entitlements = new Option<string?>("--entitlements", "Path to entitlements to embed into the signature");
+            var azureKekVaultUrl = new Option<string?>("--azure-key-vault-url", "URL to an Azure Key Vault");
+
             var signCommand = new Command("sign", "Sign code at path using given identity")
             {
-                new Argument<string>("identity", "Name of signing identity or \"-\" for ad-hoc signing"),
-                new Argument<string>("path", "Path to bundle or executable on disk"),
-                new Option<string?>("--entitlements", "Path to entitlements to embed into the signature"),
-                new Option<string?>("--azure-key-vault-url", "URL to an Azure Key Vault"),
+                identity,
+                path,
+                entitlements,
+                azureKekVaultUrl,
             };
 
-            signCommand.Handler = CommandHandler.Create<string, string, string?, string?>(HandleSign);
+            signCommand.SetHandler<string, string, string?, string?>(HandleSign, identity, path, entitlements, azureKekVaultUrl);
 
             return new RootCommand { signCommand }.Invoke(args);
         }


### PR DESCRIPTION
I'm not familiar with the `System.CommandLine` API but it seems something has changed recently, see [Announcing System.CommandLine 2.0 Beta 2 and the road to GA][1]. I think this happened because the `System.CommandLine` package is referenced with a floating version (2.0.0-*) and a breaking change was introduced.

Anyway, `CommandHandler.Create` has been moved into a new `System.CommandLine.NamingConventionBinder` compatibility NuGet package and the new way of setting up a command handler is with a new `SetHandler` extension method.

[1]: https://github.com/dotnet/command-line-api/issues/1537