### PR TITLE
Publish Melanzana to GitHub NuGet feed

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,6 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,3 +23,16 @@ jobs:
       run: dotnet test Melanzana.MachO.Tests
     - name: Test (CodeSign)
       run: dotnet test Melanzana.CodeSign.Tests
+    - name: Create NuGet packages
+      run: |
+        dotnet pack -c Release Melanzana.Streams -o nuget/
+        dotnet pack -c Release Melanzana.MachO -o nuget/
+        dotnet pack -c Release Melanzana.CodeSign -o nuget/
+    - name: Get version information
+      uses: dotnet/nbgv@master
+      id: nbgv
+    - name: Publish NuGet packages as artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: melanzana-${{ steps.nbgv.outputs.SemVer2 }}
+        path: nuget/

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,3 +35,8 @@ jobs:
       with:
         name: melanzana-${{ steps.nbgv.outputs.SemVer2 }}
         path: nuget/
+    - name: Publish NuGet packages to NuGet feed
+      run: |
+        dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+        dotnet nuget push "nuget/*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project ToolsVersion="15.0">
+    <PropertyGroup>    
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    </ItemGroup>
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1",
+    "publicReleaseRefSpec": [
+      "^refs/heads/main$",
+      "^refs/heads/releases/*"
+    ]
+}


### PR DESCRIPTION
I'd like to use Melanzana in one of my projects, and it'd be nice to be able to consume it as NuGet packages.

This PR:
- Adds Nerdbank.GitVersioning, SourceLink, so that running `nuget pack` on each commit returns a unique version number
- Runs `dotnet nuget pack` as part of the CI pipeline and publishes the packages as artifacts
- Publishes the NuGet packages to the owner's package feed when building from master

Ideally packages are (frequently) pushed to a NuGet repository which doesn't require authentication (nuget.org or Azure DevOps to name a few), but that can be a follow-up PR.