### PR TITLE
Add MachCpuSubType enumerations

### DIFF
--- a/Melanzana.MachO/MachArm64CpuSubType.cs
+++ b/Melanzana.MachO/MachArm64CpuSubType.cs
@@ -1,0 +1,34 @@
+namespace Melanzana.MachO
+{
+    /// <summary>
+    /// Defines the subtypes of the ARM 64 <see cref="MachCpuType"/>.
+    /// Defined in <c>machine.h</c>.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration matches version 7195.141.2 of XNU.
+    /// </remarks>
+    /// <seealso href="https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/mach/machine.h"/>
+    [Flags]
+    public enum MachArm64CpuSubType : uint
+    {
+        /// <summary>
+        /// All ARM64 subtypes.
+        /// </summary>
+        All = MachCpuSubType.All,
+
+        /// <summary>
+        /// The ARM64v8 CPU architecture subtype.
+        /// </summary>
+        V8 = 1,
+
+        /// <summary>
+        /// The ARM64e CPU architecture subtype.
+        /// </summary>
+        E = 2,
+
+        /// <summary>
+        /// Pointer authentication with versioned ABI.
+        /// </summary>
+        PointerAuthenticationWithVersionedAbi = 0x80000000,
+    }
+}

--- a/Melanzana.MachO/MachArmCpuSubType.cs
+++ b/Melanzana.MachO/MachArmCpuSubType.cs
@@ -1,0 +1,83 @@
+namespace Melanzana.MachO
+{
+    /// <summary>
+    /// Defines the subtypes of the ARM <see cref="MachCpuType"/>.
+    /// Defined in <c>machine.h</c>.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration matches version 7195.141.2 of XNU.
+    /// </remarks>
+    /// <seealso href="https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/mach/machine.h"/>
+    public enum MachArmCpuSubType : uint
+    {
+        /// <summary>
+        /// All ARM subtypes.
+        /// </summary>
+        All = MachCpuSubType.All,
+
+        /// <summary>
+        /// The ARMv4T architecture CPU. Part of the ARM7TDMI family.
+        /// </summary>
+        V4T = 5,
+
+        /// <summary>
+        /// The ARMv6 architecture CPU. Part of the ARMv6 family.
+        /// </summary>
+        V6 = 6,
+
+        /// <summary>
+        /// The ARMv5TEJ architecture CPU. Part of the ARM9E family.
+        /// </summary>
+        V5TEJ = 7,
+
+        /// <summary>
+        /// The XScale family of ARMv5TE CPUs.
+        /// </summary>
+        XSCALE = 8,
+
+        /// <summary>
+        /// The ARMv7 CPU
+        /// </summary>
+        V7 = 9,
+
+        /// <summary>
+        /// The ARMv7F CPU.
+        /// </summary>
+        V7F = 10,
+
+        /// <summary>
+        /// The ARMv7S CPU.
+        /// </summary>
+        V7S = 11,
+
+        /// <summary>
+        /// The ARMv7K CPU.
+        /// </summary>
+        V7K = 12,
+
+        /// <summary>
+        /// An ARMv8 architecture CPU.
+        /// </summary>
+        V8 = 13,
+
+        /// <summary>
+        /// The ARMv6-M architecture CPU. Part of the Cortex-M family.
+        /// </summary>
+        V6M = 14,
+
+        /// <summary>
+        /// The ARMv7-M architecture CPU. Part of the Cortex-M family.
+        /// </summary>
+        V7M = 15,
+
+        /// <summary>
+        /// An ARMv7E-M architecture CPU. Part of the Cortex-M family.
+        /// </summary>
+        V7EM = 16,
+
+        /// <summary>
+        /// An ARMv8M architecture CPU.
+        /// </summary>
+        V8M = 17,
+    }
+}

--- a/Melanzana.MachO/MachCpuSubType.cs
+++ b/Melanzana.MachO/MachCpuSubType.cs
@@ -1,0 +1,19 @@
+namespace Melanzana.MachO
+{
+    /// <summary>
+    /// Defines the general flags for CPU subtypes. Depending on the <see cref="MachCpuType"/>,
+    /// you should cast the value to a more specialized enumeration, such as <see cref="MachArmCpuSubType"/>.
+    /// Defined in <c>machine.h</c>.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration matches version 7195.141.2 of XNU.
+    /// </remarks>
+    /// <seealso href="https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/mach/machine.h"/>
+    public enum MachCpuSubType : uint
+    {
+        /// <summary>
+        /// All subtypes.
+        /// </summary>
+        All = 0,
+    }
+}

--- a/Melanzana.MachO/MachI386CpuSubType.cs
+++ b/Melanzana.MachO/MachI386CpuSubType.cs
@@ -1,0 +1,118 @@
+namespace Melanzana.MachO
+{
+    /// <summary>
+    /// Defines the subtypes of the i386 <see cref="MachCpuType"/>.
+    /// Defined in <c>machine.h</c>.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration matches version 7195.141.2 of XNU.
+    /// </remarks>
+    /// <seealso href="https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/mach/machine.h"/>
+    public enum MachI386CpuSubType : uint
+    {
+        /// <summary>
+        /// All i386 subtypes
+        /// </summary>
+        All = 3 + (0 << 4),
+
+        /// <summary>
+        /// The Intel 386 processor.
+        /// </summary>
+        _386 = 3 + (0 << 4),
+
+        /// <summary>
+        /// The Intel 486 processor.
+        /// </summary>
+        _486 = 4 + (0 << 4),
+
+        /// <summary>
+        /// The Intel 486SX processor.
+        /// </summary>
+        _486SX = 4 + (8 << 4),
+
+        /// <summary>
+        /// The Intel 586 processor.
+        /// </summary>
+        _586 = 5 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Pentium processor.
+        /// </summary>
+        Pentium = 5 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Pentium Pro processor.
+        /// </summary>
+        PentiumPro = 6 + (1 << 4),
+
+        /// <summary>
+        /// The Intel Pentium II (M3) processor.
+        /// </summary>
+        PentiumIIM3 = 6 + (3 << 4),
+
+        /// <summary>
+        /// The Intel Penium II (M5) processor.
+        /// </summary>
+        PentiumIIM5 = 6 + (5 << 4),
+
+        /// <summary>
+        /// The Intel Celeron processor.
+        /// </summary>
+        Celeron = 7 + (6 << 4),
+
+        /// <summary>
+        /// The Intel Celeron Mobile processor.
+        /// </summary>
+        CeleronMobile = 7 + (7 << 4),
+
+        /// <summary>
+        /// The Intel Pentium 3 processor.
+        /// </summary>
+        Pentium3 = 8 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Pentium 3 M processor.
+        /// </summary>
+        Pentium3M = 8 + (1 << 4),
+
+        /// <summary>
+        /// The Intel Pentium 3 Xeon processor.
+        /// </summary>
+        Pentium3Xeon = 8 + (2 << 4),
+
+        /// <summary>
+        /// The Intel Pentium M processor.
+        /// </summary>
+        PentiumM = 9 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Pentium 4 processor.
+        /// </summary>
+        Pentium4 = 10 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Pentium 4 M processor.
+        /// </summary>
+        Pentium4M = 10 + (1 << 4),
+
+        /// <summary>
+        /// The Intel Itanium processor.
+        /// </summary>
+        Itanium = 11 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Itanium 2 processor.
+        /// </summary>
+        Itanium2 = 11 + (1 << 4),
+
+        /// <summary>
+        /// The Intel Xeon processor.
+        /// </summary>
+        Xeon = 12 + (0 << 4),
+
+        /// <summary>
+        /// The Intel Xeon MP processor.
+        /// </summary>
+        XeonMP = 12 + (1 << 4),
+    }
+}

--- a/Melanzana.MachO/MachX8664CpuSubType.cs
+++ b/Melanzana.MachO/MachX8664CpuSubType.cs
@@ -1,0 +1,23 @@
+namespace Melanzana.MachO
+{
+    /// <summary>
+    /// Defines the subtypes of the x86_64 <see cref="MachCpuType"/>.
+    /// Defined in <c>machine.h</c>.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration matches version 7195.141.2 of XNU.
+    /// </remarks>
+    /// <seealso href="https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/mach/machine.h"/>
+    public enum X8664CpuSubType : uint
+    {
+        /// <summary>
+        /// All x86_64 CPUs
+        /// </summary>
+        All = 3,
+
+        /// <summary>
+        /// Haswell feature subset.
+        /// </summary>
+        Haswell = 8,
+    }
+}


### PR DESCRIPTION
Melanzana treats the CPU subtype as an `uint`. It may sometimes be useful to inspect the CPU subtype (particularly for arm and arm64 CPU types); this PR adds a bunch of enums to which the CPU subtype can be casted (given that you know the CPU type).