### PR TITLE
Add DerPropertyListParser

### DIFF
--- a/Melanzana.CodeSign.Tests/Data/entitlements.der
+++ b/Melanzana.CodeSign.Tests/Data/entitlements.der
@@ -1,0 +1,2 @@
+1Ê0get-task-allow01#com.apple.developer.team-identifier
+01234567890>application-identifier$0123456789.com.example.MyApplication0@keychain-access-groups0&$0123456789.com.example.MyApplication

--- a/Melanzana.CodeSign.Tests/PropertyList/DerPropertyListParserTests.cs
+++ b/Melanzana.CodeSign.Tests/PropertyList/DerPropertyListParserTests.cs
@@ -1,0 +1,52 @@
+﻿using Claunia.PropertyList;
+using Melanzana.CodeSign.PropertyList;
+using Melanzana.Streams;
+using System;
+using Xunit;
+
+namespace Melanzana.CodeSign.Tests.PropertyList
+{
+    public class DerPropertyListParserTests
+    {
+        /// <summary>
+        /// Tests the <see cref="DerPropertyListParser.Parse(ReadOnlyMemory{byte})"/> method for
+        /// embedded entitlements.
+        /// </summary>
+        [Fact]
+        public void ParseEntitlementsTest()
+        {
+            var stream = typeof(DerPropertyListParserTests).Assembly.GetManifestResourceStream("Melanzana.CodeSign.Tests.Data.entitlements.der")!;
+            var data = new byte[stream.Length];
+            stream.ReadFully(data);
+
+            var value = DerPropertyListParser.Parse(data);
+            var dict = Assert.IsType<NSDictionary>(value);
+
+            Assert.Collection(
+                dict,
+                e =>
+                {
+                    Assert.Equal("get-task-allow", e.Key);
+                    Assert.True(Assert.IsType<NSNumber>(e.Value).ToBool());
+                },
+                e =>
+                {
+                    Assert.Equal("com.apple.developer.team-identifier", e.Key);
+                    Assert.Equal("0123456789", Assert.IsType<NSString>(e.Value).ToString());
+                },
+                e =>
+                {
+                    Assert.Equal("application-identifier", e.Key);
+                    Assert.Equal("0123456789.com.example.MyApplication", Assert.IsType<NSString>(e.Value).ToString());
+                },
+                e =>
+                {
+                    Assert.Equal("keychain-access-groups", e.Key);
+
+                    var array = Assert.IsType<NSArray>(e.Value);
+                    var value = Assert.Single(array);
+                    Assert.Equal("0123456789.com.example.MyApplication", Assert.IsType<NSString>(value).ToString());
+                });
+        }
+    }
+}

--- a/Melanzana.CodeSign/PropertyList/DerPropertyListParser.cs
+++ b/Melanzana.CodeSign/PropertyList/DerPropertyListParser.cs
@@ -1,0 +1,92 @@
+﻿using Claunia.PropertyList;
+using System.Formats.Asn1;
+
+namespace Melanzana.CodeSign.PropertyList
+{
+    /// <summary>
+    /// Parses property lists in DER-encoded format.
+    /// </summary>
+    public class DerPropertyListParser
+    {
+        /// <summary>
+        /// Parses a parses a property list in DER-encoded format.
+        /// </summary>
+        /// <param name="source">
+        /// The DER-encoded property list.
+        /// </param>
+        /// <returns>
+        /// A <see cref="NSObject"/> which represents the DER-encoded property list.
+        /// </returns>
+        public static NSObject Parse(ReadOnlyMemory<byte> source)
+        {
+            AsnReader reader = new AsnReader(source, AsnEncodingRules.DER);
+            return Parse(reader);
+        }
+
+        private static NSArray ParseArray(AsnReader reader)
+        {
+            var sequenceReader = reader.ReadSequence();
+
+            NSArray value = new NSArray();
+
+            while (sequenceReader.HasData)
+            {
+                value.Add(Parse(sequenceReader));
+            }
+
+            return value;
+        }
+
+        private static NSDictionary ParseDictionary(AsnReader reader)
+        {
+            var setReader = reader.ReadSetOf();
+            NSDictionary dictionary = new NSDictionary();
+
+            // We're expecting the following structure:
+            // SET <- dictionary
+            //   SEQUENCE <- key/value
+            while (setReader.HasData)
+            {
+                var sequenceReader = setReader.ReadSequence();
+                var key = sequenceReader.ReadCharacterString(UniversalTagNumber.UTF8String);
+                var value = Parse(sequenceReader);
+
+                dictionary.Add(key, value);
+            }
+
+            return dictionary;
+        }
+
+        private static NSObject Parse(AsnReader reader)
+        {
+            var tag = reader.PeekTag();
+
+            if (tag.TagClass != TagClass.Universal)
+            {
+                throw new PropertyListFormatException($"Unexpected tag {tag}");
+            }
+
+            switch ((UniversalTagNumber)tag.TagValue)
+            {
+                case UniversalTagNumber.Boolean:
+                    // The boolean value 'true' is encoded as 0xFF instead of 0x01, which violates the
+                    // DER standards. Read it manually instead.
+                    var encodedValue = reader.ReadEncodedValue();
+                    var boolValue = AsnDecoder.ReadBoolean(encodedValue.Span, AsnEncodingRules.BER, out int _);
+                    return new NSNumber(boolValue);
+
+                case UniversalTagNumber.UTF8String:
+                    return new NSString(reader.ReadCharacterString(UniversalTagNumber.UTF8String));
+
+                case UniversalTagNumber.Set:
+                    return ParseDictionary(reader);
+
+                case UniversalTagNumber.Sequence:
+                    return ParseArray(reader);
+
+                default:
+                    throw new PropertyListFormatException($"Unexpected tag {tag}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes it easier to read DER-encoded entitlement property lists from an embedded signature.

Also, as a separate commit, reproduces a quirk in the Apple implementation where `true` is encoded as 0xFF instead of 0x01.