### PR TITLE
ResourceBuilder: Always use `/` as file separator

### DIFF
--- a/Melanzana.CodeSign/ResourceBuilder.cs
+++ b/Melanzana.CodeSign/ResourceBuilder.cs
@@ -52,7 +52,12 @@ namespace Melanzana.CodeSign
 
             foreach (var fsEntryInfo in rootDirectoryInfo.EnumerateFileSystemInfos().OrderBy(i => i.Name, StringComparer.Ordinal))
             {
-                string fsEntryPath = Path.Combine(relativePath, fsEntryInfo.Name);
+                string fsEntryPath = fsEntryInfo.Name;
+
+                if (!string.IsNullOrEmpty(relativePath))
+                {
+                    fsEntryPath = $"{relativePath}/{fsEntryInfo.Name}";
+                }
 
                 if (exclusions.Contains(fsEntryPath, StringComparer.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
`Path.Combine` would use the OS-specific file seperator, meaning `\` on Windows.  As the applications which are being signed here would only run on macOS/iOS, it makes sense to always use `/` as a file separator.