### PR TITLE
Bundle: Update ResourceRules to match those observed in an iOS package

### DIFF
--- a/Melanzana.CodeSign.Tests/SignerTests.cs
+++ b/Melanzana.CodeSign.Tests/SignerTests.cs
@@ -1,0 +1,77 @@
+﻿using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Melanzana.CodeSign.Tests
+{
+    public class SignerTests
+    {
+        private const string WebDriverAgentFileName = "WebDriverAgentRunner-Runner.zip";
+
+        [Theory]
+        [InlineData("Frameworks/XCTAutomationSupport.framework")]
+        [InlineData("Frameworks/XCTestCore.framework")]
+        [InlineData("Frameworks/XCUIAutomation.framework")]
+        [InlineData("Frameworks/XCUnit.framework")]
+        public async Task CodeResources_Roundtrip(string nestedBundlePath)
+        {
+            // Extract a fresh copy of the WebDriverAgent into a directory dedicated to this test.
+            var testDirectory = Path.GetFullPath(nameof(CodeResources_Roundtrip));
+            await ExtractWebDriverAgent(testDirectory);
+
+            // Build the resource seal and convert to a XML property list
+            var bundleDirectory = Path.Combine(testDirectory, "WebDriverAgentRunner-Runner.app", nestedBundlePath);
+            var bundle = new Bundle(bundleDirectory);
+            var signer = new Signer(new CodeSignOptions());
+            var actual = signer.BuildResourceSeal(bundle).ToXmlPropertyList();
+
+            // The newly created resource seal should match the original resource seal
+            var expected = File.ReadAllText(Path.Combine(bundleDirectory, "_CodeSignature/CodeResources"));
+            Assert.Equal(expected, actual);
+        }
+
+        private async Task ExtractWebDriverAgent(string path)
+        {
+            await DownloadWebDriverAgent(WebDriverAgentFileName);
+
+            if (!Directory.Exists(path))
+            {
+                using (Stream stream = File.OpenRead(WebDriverAgentFileName))
+                using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    archive.ExtractToDirectory(path);
+                }
+            }
+        }
+
+        private async Task DownloadWebDriverAgent(string path, string version = "v4.10.10")
+        {
+            if (!File.Exists(path))
+            {
+                using (var targetStream = File.Create(path))
+                using (var client = new HttpClient())
+                using (var sourceStream = await client.GetStreamAsync($"https://github.com/appium/WebDriverAgent/releases/download/{version}/WebDriverAgentRunner-Runner.zip"))
+                {
+                    await sourceStream.CopyToAsync(targetStream);
+                }
+            }
+        }
+
+        private static void DeleteResources(string path)
+        {
+            foreach (var dir in Directory.GetDirectories(path))
+            {
+                if (Path.GetFileName(dir) == "_CodeSignature")
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+                else
+                {
+                    DeleteResources(dir);
+                }
+            }
+        }
+    }
+}

--- a/Melanzana.CodeSign/Bundle.cs
+++ b/Melanzana.CodeSign/Bundle.cs
@@ -48,7 +48,7 @@ namespace Melanzana.CodeSign
                     {
                         mainExecutable = (string)bundleExecutable;
                     }
-                    
+
                     if (!File.Exists(Path.Combine(ContentsPath, mainExecutable)))
                     {
                         mainExecutable = null;
@@ -89,7 +89,17 @@ namespace Melanzana.CodeSign
 
             if (useV2Rules)
             {
+                builder.AddRule(new ResourceRule(".*\\.dSYM($|/)") { Weight = 11 });
+
+                builder.AddRule(new ResourceRule("^(.*/)?\\.DS_Store$") { IsOmitted = true, Weight = 2000 });
+
                 builder.AddRule(new ResourceRule("^.*"));
+
+                builder.AddRule(new ResourceRule("^.*\\.lproj/") { IsOptional = true, Weight = 1000 });
+
+                builder.AddRule(new ResourceRule("^.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
+
+                builder.AddRule(new ResourceRule("^Base\\.lproj/") { Weight = 1010 });
 
                 // On macOS include nested signatures
                 if (hasResources)
@@ -99,27 +109,23 @@ namespace Melanzana.CodeSign
                     builder.AddRule(new ResourceRule($"^{resourcePrefix}") { Weight = 20 });
                 }
 
-                builder.AddRule(new ResourceRule(".*\\.dSYM($|/)") { Weight = 11 });
-
                 // Exclude specific files:
                 builder.AddRule(new ResourceRule("^Info\\.plist$") { IsOmitted = true, Weight = 20 });
                 builder.AddRule(new ResourceRule("^PkgInfo$") { IsOmitted = true, Weight = 20 });
 
                 // Include specific files:
                 builder.AddRule(new ResourceRule("^embedded\\.provisionprofile$") { Weight = 20 });
-                builder.AddRule(new ResourceRule("^version.plist$") { Weight = 20 });
-
-                builder.AddRule(new ResourceRule("^(.*/)?\\.DS_Store$") { IsOmitted = true, Weight = 2000 });
+                builder.AddRule(new ResourceRule("^version\\.plist$") { Weight = 20 });
             }
             else
             {
-                builder.AddRule(new ResourceRule("^version.plist$"));
                 builder.AddRule(new ResourceRule(hasResources ? $"^{resourcePrefix}" : "^.*"));
-            }
 
-            builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/") { IsOptional = true, Weight = 1000 });
-            builder.AddRule(new ResourceRule($"^{resourcePrefix}Base\\.lproj/") { Weight = 1010 });
-            builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
+                builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/") { IsOptional = true, Weight = 1000 });
+                builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
+                builder.AddRule(new ResourceRule($"^{resourcePrefix}Base\\.lproj/") { Weight = 1010 });
+                builder.AddRule(new ResourceRule("^version.plist$"));
+            }
 
             // Add implicit exclusions
             builder.AddExclusion("_CodeSignature");

--- a/Melanzana.CodeSign/Bundle.cs
+++ b/Melanzana.CodeSign/Bundle.cs
@@ -89,17 +89,7 @@ namespace Melanzana.CodeSign
 
             if (useV2Rules)
             {
-                builder.AddRule(new ResourceRule(".*\\.dSYM($|/)") { Weight = 11 });
-
-                builder.AddRule(new ResourceRule("^(.*/)?\\.DS_Store$") { IsOmitted = true, Weight = 2000 });
-
                 builder.AddRule(new ResourceRule("^.*"));
-
-                builder.AddRule(new ResourceRule("^.*\\.lproj/") { IsOptional = true, Weight = 1000 });
-
-                builder.AddRule(new ResourceRule("^.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
-
-                builder.AddRule(new ResourceRule("^Base\\.lproj/") { Weight = 1010 });
 
                 // On macOS include nested signatures
                 if (hasResources)
@@ -109,6 +99,8 @@ namespace Melanzana.CodeSign
                     builder.AddRule(new ResourceRule($"^{resourcePrefix}") { Weight = 20 });
                 }
 
+                builder.AddRule(new ResourceRule(".*\\.dSYM($|/)") { Weight = 11 });
+
                 // Exclude specific files:
                 builder.AddRule(new ResourceRule("^Info\\.plist$") { IsOmitted = true, Weight = 20 });
                 builder.AddRule(new ResourceRule("^PkgInfo$") { IsOmitted = true, Weight = 20 });
@@ -116,16 +108,20 @@ namespace Melanzana.CodeSign
                 // Include specific files:
                 builder.AddRule(new ResourceRule("^embedded\\.provisionprofile$") { Weight = 20 });
                 builder.AddRule(new ResourceRule("^version\\.plist$") { Weight = 20 });
+
+                builder.AddRule(new ResourceRule("^(.*/)?\\.DS_Store$") { IsOmitted = true, Weight = 2000 });
             }
             else
             {
-                builder.AddRule(new ResourceRule(hasResources ? $"^{resourcePrefix}" : "^.*"));
-
-                builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/") { IsOptional = true, Weight = 1000 });
-                builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
-                builder.AddRule(new ResourceRule($"^{resourcePrefix}Base\\.lproj/") { Weight = 1010 });
+                // NOTE: Apple historically used `version.plist` instead of `version\\.plist`, so this is
+                // bug-for-bug compatibility.
                 builder.AddRule(new ResourceRule("^version.plist$"));
+                builder.AddRule(new ResourceRule(hasResources ? $"^{resourcePrefix}" : "^.*"));
             }
+
+            builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/") { IsOptional = true, Weight = 1000 });
+            builder.AddRule(new ResourceRule($"^{resourcePrefix}Base\\.lproj/") { Weight = 1010 });
+            builder.AddRule(new ResourceRule($"^{resourcePrefix}.*\\.lproj/locversion.plist$") { IsOmitted = true, Weight = 1100 });
 
             // Add implicit exclusions
             builder.AddExclusion("_CodeSignature");

--- a/Melanzana.CodeSign/Signer.cs
+++ b/Melanzana.CodeSign/Signer.cs
@@ -262,14 +262,14 @@ namespace Melanzana.CodeSign
                 else
                 {
                     var rulePList = new NSDictionary();
-                    if (rule.Weight != 1)
-                        rulePList.Add("weight", (double)rule.Weight);
-                    if (rule.IsOmitted)
-                        rulePList.Add("omit", true);
                     if (rule.IsOptional)
                         rulePList.Add("optional", true);
                     if (rule.IsNested)
                         rulePList.Add("nested", true);
+                    if (rule.IsOmitted)
+                        rulePList.Add("omit", true);
+                    if (rule.Weight != 1)
+                        rulePList.Add("weight", (double)rule.Weight);
                     rulesPList.Add(rule.Pattern, rulePList);
                 }
             }
@@ -277,7 +277,7 @@ namespace Melanzana.CodeSign
             return rulesPList;
         }
 
-        private NSDictionary BuildResourceSeal(Bundle bundle)
+        public NSDictionary BuildResourceSeal(Bundle bundle)
         {
             var sha1 = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
             var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);


### PR DESCRIPTION
I've noticed that the resource rules which are generated do not match those observed in an iOS application bundle.

This PR:
- Updates the resource rules to match those seen in frameworks embedded in the WebDriverAgent
- Adds a unit test which uses the Signer to generate the `_CodeSignature/CodeResources` asset, and compare its output with those of the asset generated by the default tooling 