### PR TITLE
DynamicLinkEditSymbolTable: Implement LinkEditData

### DIFF
--- a/Melanzana.MachO.Tests/CreateTests.cs
+++ b/Melanzana.MachO.Tests/CreateTests.cs
@@ -149,7 +149,7 @@ namespace Melanzana.MachO.Tests
             symbolTable.Symbols.Add(new MachSymbol { Name = "ltmp0", Section = textSection, Value = 0, Descriptor = 0, Type = MachSymbolType.Section });
             symbolTable.Symbols.Add(new MachSymbol { Name = "ltmp1", Section = compactUnwindSection, Value = 0x18, Descriptor = 0, Type = MachSymbolType.Section });
             symbolTable.Symbols.Add(new MachSymbol { Name = "_main", Section = textSection, Value = 0, Descriptor = 0, Type = MachSymbolType.Section | MachSymbolType.External });
-            objectFile.LoadCommands.Add(new MachDynamicLinkEditSymbolTable(Stream.Null, symbolTable));
+            objectFile.LoadCommands.Add(new MachDynamicLinkEditSymbolTable(objectFile, Stream.Null, symbolTable));
 
             objectFile.UpdateLayout();
             Assert.Equal(0u, segment.VirtualAddress);

--- a/Melanzana.MachO.Tests/CreateTests.cs
+++ b/Melanzana.MachO.Tests/CreateTests.cs
@@ -149,7 +149,7 @@ namespace Melanzana.MachO.Tests
             symbolTable.Symbols.Add(new MachSymbol { Name = "ltmp0", Section = textSection, Value = 0, Descriptor = 0, Type = MachSymbolType.Section });
             symbolTable.Symbols.Add(new MachSymbol { Name = "ltmp1", Section = compactUnwindSection, Value = 0x18, Descriptor = 0, Type = MachSymbolType.Section });
             symbolTable.Symbols.Add(new MachSymbol { Name = "_main", Section = textSection, Value = 0, Descriptor = 0, Type = MachSymbolType.Section | MachSymbolType.External });
-            objectFile.LoadCommands.Add(new MachDynamicLinkEditSymbolTable(symbolTable));
+            objectFile.LoadCommands.Add(new MachDynamicLinkEditSymbolTable(Stream.Null, symbolTable));
 
             objectFile.UpdateLayout();
             Assert.Equal(0u, segment.VirtualAddress);

--- a/Melanzana.MachO/MachReader.cs
+++ b/Melanzana.MachO/MachReader.cs
@@ -216,12 +216,12 @@ namespace Melanzana.MachO
                 new MachLinkEditData(stream, symbolTableHeader.StringTableOffset, symbolTableHeader.StringTableSize));
         }
 
-        private static MachDynamicLinkEditSymbolTable ReadDynamicLinkEditSymbolTable(ReadOnlySpan<byte> loadCommandPtr, bool isLittleEndian)
+        private static MachDynamicLinkEditSymbolTable ReadDynamicLinkEditSymbolTable(ReadOnlySpan<byte> loadCommandPtr, bool isLittleEndian, Stream stream)
         {
             var dynamicSymbolTableHeader = DynamicSymbolTableCommandHeader.Read(loadCommandPtr.Slice(LoadCommandHeader.BinarySize), isLittleEndian, out var _);
 
             // TODO: Clean up
-            return new MachDynamicLinkEditSymbolTable(dynamicSymbolTableHeader);
+            return new MachDynamicLinkEditSymbolTable(stream, dynamicSymbolTableHeader);
         }
 
         private static MachDyldInfo ReadDyldInfo(
@@ -358,7 +358,7 @@ namespace Melanzana.MachO
                     MachLoadCommandType.VersionMinWatchOS => ReadVersionMinCommand<MachVersionMinWatchOS>(loadCommandPtr, isLittleEndian),
                     MachLoadCommandType.BuildVersion => ReadBuildVersion(loadCommandPtr, isLittleEndian),
                     MachLoadCommandType.SymbolTable => ReadSymbolTable(loadCommandPtr, objectFile, stream),
-                    MachLoadCommandType.DynamicLinkEditSymbolTable => ReadDynamicLinkEditSymbolTable(loadCommandPtr, isLittleEndian),
+                    MachLoadCommandType.DynamicLinkEditSymbolTable => ReadDynamicLinkEditSymbolTable(loadCommandPtr, isLittleEndian, stream),
                     MachLoadCommandType.DyldInfo => ReadDyldInfo(loadCommandHeader.CommandType, loadCommandPtr, objectFile, stream),
                     MachLoadCommandType.DyldInfoOnly => ReadDyldInfo(loadCommandHeader.CommandType, loadCommandPtr, objectFile, stream),
                     MachLoadCommandType.TowLevelHints => ReadTwoLevelHints(loadCommandPtr, objectFile, stream),

--- a/Melanzana.MachO/MachReader.cs
+++ b/Melanzana.MachO/MachReader.cs
@@ -216,12 +216,12 @@ namespace Melanzana.MachO
                 new MachLinkEditData(stream, symbolTableHeader.StringTableOffset, symbolTableHeader.StringTableSize));
         }
 
-        private static MachDynamicLinkEditSymbolTable ReadDynamicLinkEditSymbolTable(ReadOnlySpan<byte> loadCommandPtr, bool isLittleEndian, Stream stream)
+        private static MachDynamicLinkEditSymbolTable ReadDynamicLinkEditSymbolTable(ReadOnlySpan<byte> loadCommandPtr, MachObjectFile objectFile, Stream stream)
         {
-            var dynamicSymbolTableHeader = DynamicSymbolTableCommandHeader.Read(loadCommandPtr.Slice(LoadCommandHeader.BinarySize), isLittleEndian, out var _);
+            var dynamicSymbolTableHeader = DynamicSymbolTableCommandHeader.Read(loadCommandPtr.Slice(LoadCommandHeader.BinarySize), objectFile.IsLittleEndian, out var _);
 
             // TODO: Clean up
-            return new MachDynamicLinkEditSymbolTable(stream, dynamicSymbolTableHeader);
+            return new MachDynamicLinkEditSymbolTable(objectFile, stream, dynamicSymbolTableHeader);
         }
 
         private static MachDyldInfo ReadDyldInfo(
@@ -358,7 +358,7 @@ namespace Melanzana.MachO
                     MachLoadCommandType.VersionMinWatchOS => ReadVersionMinCommand<MachVersionMinWatchOS>(loadCommandPtr, isLittleEndian),
                     MachLoadCommandType.BuildVersion => ReadBuildVersion(loadCommandPtr, isLittleEndian),
                     MachLoadCommandType.SymbolTable => ReadSymbolTable(loadCommandPtr, objectFile, stream),
-                    MachLoadCommandType.DynamicLinkEditSymbolTable => ReadDynamicLinkEditSymbolTable(loadCommandPtr, isLittleEndian, stream),
+                    MachLoadCommandType.DynamicLinkEditSymbolTable => ReadDynamicLinkEditSymbolTable(loadCommandPtr, objectFile, stream),
                     MachLoadCommandType.DyldInfo => ReadDyldInfo(loadCommandHeader.CommandType, loadCommandPtr, objectFile, stream),
                     MachLoadCommandType.DyldInfoOnly => ReadDyldInfo(loadCommandHeader.CommandType, loadCommandPtr, objectFile, stream),
                     MachLoadCommandType.TowLevelHints => ReadTwoLevelHints(loadCommandPtr, objectFile, stream),


### PR DESCRIPTION
Roundtripping of Mach objects which contain an indirect symbol table would fail because no corresponding MachLinkEditData object was created.

This commit implements DynamicLinkEditSymbolTable.LinkEditData and creates MachLinkEditData objects for all regions referenced from the dynamic link edit symbol table.

Because I don't know the size of entries in all regions other than the indirect symbol table, I added a Debug.Assert statement asserting that these regions are empty.