### PR TITLE
MachWriter: Support writing fat objects which contain a single object

### DIFF
--- a/Melanzana.MachO.Tests/ValidatingStream.cs
+++ b/Melanzana.MachO.Tests/ValidatingStream.cs
@@ -1,0 +1,69 @@
+﻿using Melanzana.Streams;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Melanzana.MachO.Tests
+{
+    public class ValidatingStream : Stream
+    {
+        private readonly Stream expectedStream;
+
+        public ValidatingStream(Stream expectedStream)
+        {
+            this.expectedStream = expectedStream ?? throw new ArgumentNullException(nameof(expectedStream));
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => expectedStream.CanSeek;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position
+        {
+            get => expectedStream.Position;
+            set => expectedStream.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return this.expectedStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var expected = new byte[count];
+            this.expectedStream.ReadFully(expected);
+
+            var actual = new byte[count];
+            Array.Copy(buffer, offset, actual, 0, count);
+
+            if (count < 32)
+            {
+                // Gives us a more concise error message.
+                Assert.Equal(Convert.ToHexString(expected), Convert.ToHexString(actual));
+            }
+            else
+            {
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/Melanzana.MachO/MachWriter.cs
+++ b/Melanzana.MachO/MachWriter.cs
@@ -595,12 +595,9 @@ namespace Melanzana.MachO
 
         public static void Write(Stream stream, IList<MachObjectFile> objectFiles)
         {
-            if (objectFiles.Count == 1)
-            {
-                Write(stream, objectFiles[0]);
-            }
-            else if (objectFiles.Count > 1)
-            {
+            // Always use a fat object, even if the caller only passes one object file.
+            // Callers wishing to write a non-fat archive can call Write(Stream, MachObjectFile)
+            // to express their intent.
                 var fatMagic = new byte[4];
                 var fatHeader = new FatHeader { NumberOfFatArchitectures = (uint)objectFiles.Count };
                 var fatHeaderBytes = new byte[FatHeader.BinarySize];

--- a/Melanzana.MachO/MachWriter.cs
+++ b/Melanzana.MachO/MachWriter.cs
@@ -642,4 +642,3 @@ namespace Melanzana.MachO
             }
         }
     }
-}


### PR DESCRIPTION
The copies of WebDriverAgent which I have are fat Mach objects which contain a single Mach object.  Currently the API exposes no way of creating such objects; this commit fixes that.