### PR TITLE
Add roundtrip tests for all executables/libraries in the WDA bundle

### DIFF
--- a/Melanzana.MachO.Tests/RoundtripTests.cs
+++ b/Melanzana.MachO.Tests/RoundtripTests.cs
@@ -1,12 +1,16 @@
-using Xunit;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using Melanzana.Streams;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace Melanzana.MachO.Tests
 {
     public class RoundtripTests
     {
+        private const string WebDriverAgentFileName = "WebDriverAgentRunner-Runner.zip";
+
         private static void TestRoundtrip(Stream aOutStream)
         {
             var objectFile = MachReader.Read(aOutStream).Single();
@@ -34,7 +38,7 @@ namespace Melanzana.MachO.Tests
                 outputStream.Seek(0, SeekOrigin.Begin);
 
                 MachWriter.Write(outputStream, objectFiles);
-        }
+            }
         }
 
         [Fact]
@@ -63,6 +67,50 @@ namespace Melanzana.MachO.Tests
         {
             var aOutStream = typeof(RoundtripTests).Assembly.GetManifestResourceStream("Melanzana.MachO.Tests.Data.rpath.out")!;
             TestRoundtrip(aOutStream);
+        }
+
+        [Theory]
+        [InlineData("WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner")]
+        [InlineData("WebDriverAgentRunner-Runner.app/Frameworks/XCTAutomationSupport.framework/XCTAutomationSupport")]
+        [InlineData("WebDriverAgentRunner-Runner.app/Frameworks/XCTest.framework/XCTest")]
+        [InlineData("WebDriverAgentRunner-Runner.app/Frameworks/XCTestCore.framework/XCTestCore")]
+        [InlineData("WebDriverAgentRunner-Runner.app/Frameworks/XCUIAutomation.framework/XCUIAutomation")]
+        [InlineData("WebDriverAgentRunner-Runner.app/Frameworks/XCUnit.framework/XCUnit")]
+        [InlineData("WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/WebDriverAgentRunner")]
+        [InlineData("WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework/WebDriverAgentLib")]
+        public async Task WebDriverAgentRunnerRoundtrip(string entryName)
+        {
+            await DownloadWebDriverAgent(WebDriverAgentFileName);
+
+            using (var bundleStream = File.OpenRead(WebDriverAgentFileName))
+            using (var zipArchive = new ZipArchive(bundleStream, ZipArchiveMode.Read))
+            using (var machObjectZipStream = zipArchive.GetEntry(entryName)!.Open())
+            using (var machObjectStream = new MemoryStream())
+            {
+                machObjectZipStream.CopyTo(machObjectStream);
+
+                if (MachReader.IsFatMach(machObjectStream))
+                {
+                    TestFatRoundtrip(machObjectStream);
+                }
+                else
+                {
+                    TestRoundtrip(machObjectStream);
+                }
+            }
+        }
+
+        private async Task DownloadWebDriverAgent(string path, string version = "v4.10.10")
+        {
+            if (!File.Exists(path))
+            {
+                using (var targetStream = File.Create(path))
+                using (var client = new HttpClient())
+                using (var sourceStream = await client.GetStreamAsync($"https://github.com/appium/WebDriverAgent/releases/download/{version}/WebDriverAgentRunner-Runner.zip"))
+                {
+                    await sourceStream.CopyToAsync(targetStream);
+                }
+            }
         }
     }
 }

--- a/Melanzana.MachO.Tests/ValidatingStream.cs
+++ b/Melanzana.MachO.Tests/ValidatingStream.cs
@@ -1,6 +1,7 @@
 ﻿using Melanzana.Streams;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Melanzana.MachO.Tests
@@ -62,7 +63,9 @@ namespace Melanzana.MachO.Tests
             }
             else
             {
-                Assert.Equal(expected, actual);
+                // Assert.Equal for large byte arrays does not perform particularly well;
+                // use SequenceEqual instead.
+                Assert.True(expected.SequenceEqual(actual));
             }
         }
     }


### PR DESCRIPTION
Adds an integration which roundtrips all executables/libraries in the WDA bundle.

- Acts as a non-regression test for the PRs which went in recently (thanks!)
- The WDA bundle itself is downloaded once (by the unit test itself) and then cached; we can revisit this later if needed
- There's a new `MachReader.IsFatMach` method which allows determining whether an object is a Fat archive or not