### PR TITLE
MachReader.Read: Don't use an iterator

### DIFF
--- a/Melanzana.MachO/MachReader.cs
+++ b/Melanzana.MachO/MachReader.cs
@@ -415,10 +415,12 @@ namespace Melanzana.MachO
             return magic == MachMagic.FatMagicLittleEndian || magic == MachMagic.FatMagicBigEndian;
         }
 
-        public static IEnumerable<MachObjectFile> Read(Stream stream)
+        public static IList<MachObjectFile> Read(Stream stream)
         {
             var magic = ReadMagic(stream);
             var magicBuffer = new byte[4];
+
+            List<MachObjectFile> values = new List<MachObjectFile>();
 
             if (magic == MachMagic.FatMagicLittleEndian || magic == MachMagic.FatMagicBigEndian)
             {
@@ -433,13 +435,15 @@ namespace Melanzana.MachO
                     var machOSlice = stream.Slice(fatArchHeader.Offset, fatArchHeader.Size);
                     machOSlice.ReadFully(magicBuffer);
                     magic = (MachMagic)BinaryPrimitives.ReadUInt32BigEndian(magicBuffer);
-                    yield return ReadSingle(fatArchHeader, magic, machOSlice);
+                    values.Add(ReadSingle(fatArchHeader, magic, machOSlice));
                 }
             }
             else
             {
-                yield return ReadSingle(null, magic, stream);
+                values.Add(ReadSingle(null, magic, stream));
             }
+
+            return values;
         }
     }
 }


### PR DESCRIPTION
MachReader.Read will read the header of the a fat mach object, and will create a MachObjectFile for each mach object in the fat mach object.

It currently does so in an iterator.  This reads a MachFatObject, yields control to the caller, and then reads the next MachFatObject.  However, the method does assume that the state of `stream` does not change.  That's not guaranteed to be the case -- a caller could write code like this:

```csharp
foreach(var mach in Read(stream))
{
    // Read data from the mach object, which will
    // alter the state of `stream`
}
```

To avoid this, change `MachReader.Read` to enumerate all architectures, create `MachObjectFile` objects, and only then yield control to the caller.