### PR TITLE
MachLinkEditData: Implement .ToString(), keep track of parents

### DIFF
--- a/Melanzana.MachO/LoadCommands/MachDyldInfo.cs
+++ b/Melanzana.MachO/LoadCommands/MachDyldInfo.cs
@@ -29,10 +29,15 @@ namespace Melanzana.MachO
             ArgumentNullException.ThrowIfNull(exportData);
 
             RebaseData = rebaseData;
+            RebaseData.Parent = this;
             BindData = bindData;
+            BindData.Parent = this;
             WeakBindData = weakBindData;
+            WeakBindData.Parent = this;
             LazyBindData = lazyBindData;
+            LazyBindData.Parent = this;
             ExportData = exportData;
+            ExportData.Parent = this;
         }
 
         public MachLinkEditData RebaseData { get; private init; }

--- a/Melanzana.MachO/LoadCommands/MachSection.cs
+++ b/Melanzana.MachO/LoadCommands/MachSection.cs
@@ -37,6 +37,9 @@ namespace Melanzana.MachO
             this.SectionName = sectionName;
             this.dataStream = stream;
             this.relocationData = relocationData;
+
+            if(this.relocationData != null)
+                this.relocationData.Parent = this;
         }
 
         /// <summary>

--- a/Melanzana.MachO/LoadCommands/MachSymbolTable.cs
+++ b/Melanzana.MachO/LoadCommands/MachSymbolTable.cs
@@ -31,7 +31,9 @@ namespace Melanzana.MachO
 
             this.objectFile = objectFile;
             this.symbolTableData = symbolTableData;
+            this.symbolTableData.Parent = this;
             this.stringTableData = stringTableData;
+            this.stringTableData.Parent = this;
 
             // Create a section map now since the section indexes may change later
             sectionMap = new Dictionary<byte, MachSection>();

--- a/Melanzana.MachO/LoadCommands/MachTwoLevelHints.cs
+++ b/Melanzana.MachO/LoadCommands/MachTwoLevelHints.cs
@@ -7,6 +7,7 @@ namespace Melanzana.MachO
         public MachTwoLevelHints(MachObjectFile objectFile, MachLinkEditData data)
         {
             Data = data;
+            Data.Parent = this;
         }
 
         public uint FileOffset => Data.FileOffset;

--- a/Melanzana.MachO/MachLinkEditData.cs
+++ b/Melanzana.MachO/MachLinkEditData.cs
@@ -26,6 +26,8 @@ namespace Melanzana.MachO
             this.FileOffset = offset;
         }
 
+        public object? Parent { get; set; }
+
         public uint FileOffset { get; set; }
 
         public ulong Size
@@ -63,5 +65,7 @@ namespace Melanzana.MachO
             dataStream = new UnclosableMemoryStream();
             return dataStream;
         }
+
+        public override string ToString() => $"Link Edit Data: 0x{FileOffset:X}-0x{FileOffset + Size:X} (0x{Size:X})";
     }
 }


### PR DESCRIPTION
Make debugging a bit easier by:
- Keeping track of the parent of `MachLinkEditData` objects
- Implement a `.ToString()` which returns the start and end of the range, as well as the length